### PR TITLE
Add AnveVoice to Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@
 ## Platforms
 
 - [Amazon Lex](https://aws.amazon.com/lex/) - An AWS service for building conversational interfaces for applications using voice and text.
+- [AnveVoice](https://anvevoice.app) - Voice AI agent for websites with agentic DOM actions — navigates pages, fills forms, clicks buttons autonomously. 50+ languages, <700ms latency, one-line embed. Free tier.
 - [Chai](https://chai.ml/) - Open-source platform for developers to build chatbots using Python and deploy them to the Chai mobile app.
 - [Dasha](https://dasha.ai/) - Conversational AI platform as a service with a strong focus on voice.
 - [Dialogflow](https://cloud.google.com/dialogflow) - Lifelike Conversational AI with state-of-the-art virtual agents by Google.


### PR DESCRIPTION
## Summary
- Adds [AnveVoice](https://anvevoice.app) to the **Platforms** section in alphabetical order.
- AnveVoice is a voice-first AI agent platform for websites that trains on site content, performs DOM actions (navigate, scroll, fill forms), and converses with visitors in 50+ languages with sub-700ms latency.